### PR TITLE
fix: base partial voting production ready

### DIFF
--- a/contracts/facets/governance/voting/PartialVotingFacet.sol
+++ b/contracts/facets/governance/voting/PartialVotingFacet.sol
@@ -120,12 +120,27 @@ contract PartialVotingFacet is IPartialVotingFacet, AuthConsumer
             return false;
         }
 
-        // The voter is trying to vote with more voting power than they have avaliable.
-        if (_voteData.amount > votingPower) {
-            return false;
+        if (_proposal.parameters.votingMode == VotingMode.MultiplePartialVote) {
+            uint alreadyUsedPower;
+            for (uint i; i < _proposal.voters[_voter].length; ) {
+                alreadyUsedPower += _proposal.voters[_voter][i].amount;
+                unchecked {
+                    i++;
+                }
+            }
+            
+            if (_voteData.amount + alreadyUsedPower > votingPower) {
+                return false;
+            }
+        }
+        else {
+            // The voter is trying to vote with more voting power than they have avaliable.
+            if (_voteData.amount > votingPower) {
+                return false;
+            }
         }
 
-        // In multi vote the voter is not allowed to vote with more voting power than the maximum
+        // In partial vote the voter is not allowed to vote with more voting power than the maximum
         if (_voteData.amount > _proposal.parameters.maxSingleWalletPower &&
             _proposal.parameters.votingMode != VotingMode.SingleVote
         ) {


### PR DESCRIPTION
# Description

Made checks in the partial voting facet so it can also be used as on its own, instead of just in combination with partial burn voting. It does not make sense to use partial voting in MultiplePartialVote mode without burning, but no doubt someone will find a usecase for it or use it accidently. So now it is safe for production :). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The normal unit tests pass. Dedicated test will be added after the testing framework rework.
