### PR TITLE
Fix/sdk/verification contract abi

### DIFF
--- a/sdk/src/abi/verificationContractAbi.ts
+++ b/sdk/src/abi/verificationContractAbi.ts
@@ -1,0 +1,109 @@
+export const verificationContractAbi = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_toCheck",
+        type: "address",
+      },
+    ],
+    name: "getStamps",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "string",
+            name: "providerId",
+            type: "string",
+          },
+          {
+            internalType: "string",
+            name: "userHash",
+            type: "string",
+          },
+          {
+            internalType: "uint64[]",
+            name: "verifiedAt",
+            type: "uint64[]",
+          },
+        ],
+        internalType: "struct GithubVerification.Stamp[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getThresholdHistory",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "uint64",
+            name: "timestamp",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "threshold",
+            type: "uint64",
+          },
+        ],
+        internalType: "struct GithubVerification.Threshold[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "_providerId",
+        type: "string",
+      },
+    ],
+    name: "unverify",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_toVerify",
+        type: "address",
+      },
+      {
+        internalType: "string",
+        name: "_userHash",
+        type: "string",
+      },
+      {
+        internalType: "uint64",
+        name: "_timestamp",
+        type: "uint64",
+      },
+      {
+        internalType: "string",
+        name: "_providerId",
+        type: "string",
+      },
+      {
+        internalType: "bytes",
+        name: "_proofSignature",
+        type: "bytes",
+      },
+    ],
+    name: "verifyAddress",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];

--- a/sdk/src/verification.ts
+++ b/sdk/src/verification.ts
@@ -3,6 +3,7 @@ import { GithubVerification } from "../../typechain-types";
 import { DiamondGovernanceSugar, Stamp, VerificationThreshold } from "./sugar";
 import { BigNumber } from "ethers";
 import { Signer } from "@ethersproject/abstract-signer";
+import { verificationContractAbi } from "./abi/verificationContractAbi";
 
 /**
  * VerificationSugar is a class that provides methods for interacting with the verification contract.
@@ -13,7 +14,7 @@ import { Signer } from "@ethersproject/abstract-signer";
 export class VerificationSugar {
   /**
    * Cache for the verification contract and threshold history
-   * 
+   *
    * @remarks
    * This cache is used to reduce the number of calls to the blockchain, the cache is filled on the first call to a method that requires it
    */
@@ -37,13 +38,12 @@ export class VerificationSugar {
   public async GetVerificationContract(): Promise<GithubVerification> {
     if (this.cache.verificationContract == null) {
       const verificationContractAddress =
-        await this.GetVerificationContractAddress();
-      // this.cache.verificationContract = (await ethers.getContractAt(
-      //   "GithubVerification",
-      //   verificationContractAddress,
-      //   this.signer
-      // )) as GithubVerification;
-      this.cache.verificationContract = {} as GithubVerification;
+        await this.sugar.GetVerificationContractAddress();
+      this.cache.verificationContract = new ethers.Contract(
+        verificationContractAddress,
+        verificationContractAbi,
+        this.signer
+      ) as GithubVerification;
     }
     return this.cache.verificationContract;
   }
@@ -85,7 +85,7 @@ export class VerificationSugar {
     const currentTimestamp = Math.round(Date.now() / 1000);
 
     const lastVerifiedAt = stamp
-      ? stamp[2][stamp[2].length -1]
+      ? stamp[2][stamp[2].length - 1]
       : BigNumber.from(0);
 
     // Retrieve the threshold history, and the threshold for the current timestamp
@@ -104,7 +104,9 @@ export class VerificationSugar {
       thresholdHistory.length > 0 &&
       currentTimestamp >= lastVerifiedAt.toNumber();
 
-    const expirationDate = lastVerifiedAt.add(threshold.mul(24 * 60 * 60)).toNumber();
+    const expirationDate = lastVerifiedAt
+      .add(threshold.mul(24 * 60 * 60))
+      .toNumber();
 
     const verified =
       preCondition && stamp != null && currentTimestamp < expirationDate;
@@ -157,14 +159,6 @@ export class VerificationSugar {
   public async Unverify(providerId: string): Promise<void> {
     const verificationContract = await this.GetVerificationContract();
     await verificationContract.unverify(providerId);
-  }
-
-  /**
-   * Gets the verification contract address
-   * @returns The verification contract address
-   */
-  private async GetVerificationContractAddress(): Promise<string> {
-    return this.sugar.GetVerificationContractAddress();
   }
 
   /**

--- a/sdk/src/verification.ts
+++ b/sdk/src/verification.ts
@@ -101,8 +101,8 @@ export class VerificationSugar {
       stamp[2] != null &&
       stamp[2].length > 0 &&
       thresholdHistory != null &&
-      thresholdHistory.length > 0 &&
-      currentTimestamp >= lastVerifiedAt.toNumber();
+      thresholdHistory.length > 0; /* &&
+      currentTimestamp >= lastVerifiedAt.toNumber(); */
 
     const expirationDate = lastVerifiedAt
       .add(threshold.mul(24 * 60 * 60))

--- a/sdk/src/verification.ts
+++ b/sdk/src/verification.ts
@@ -101,8 +101,7 @@ export class VerificationSugar {
       stamp[2] != null &&
       stamp[2].length > 0 &&
       thresholdHistory != null &&
-      thresholdHistory.length > 0; /* &&
-      currentTimestamp >= lastVerifiedAt.toNumber(); */
+      thresholdHistory.length > 0; 
 
     const expirationDate = lastVerifiedAt
       .add(threshold.mul(24 * 60 * 60))

--- a/test/Test_SDK.ts
+++ b/test/Test_SDK.ts
@@ -166,7 +166,7 @@ describe("SDK", function () {
   // - GetExpiration
   // - GetVerificationContract
   // - GetVerificationContractAddress 
-  it.only("(un)verifies correctly & retrieves stamps", async function() {
+  it("(un)verifies correctly & retrieves stamps", async function() {
     const { DiamondGovernance } = await loadFixture(deployAragonDAOWithFramework);
     const [owner] = await ethers.getSigners();
 

--- a/test/Test_SDK.ts
+++ b/test/Test_SDK.ts
@@ -146,7 +146,6 @@ describe("SDK", function () {
 
   // Test to retrieve threshold history
   it("get verification threshold history", async function () {
-    return; // Verification part of SDK needs update
     const { DiamondGovernance } = await loadFixture(deployAragonDAOAndVerifyFixture);
     await getVotingPower(DiamondGovernance);
     const [owner] = await ethers.getSigners();


### PR DESCRIPTION
# Description

Added an abi for the verification contract and fixed the two tests for verification through the sdk.
Note that for the main verification test I tinkered with the current timestamp to take into account that hardhat increments the block time for every contract deployed. The precondition for GetExpiration now no longer checks to see if the current timestamp is greater than (or equal to) the timestamp of the last verification of the stamp, but this should not have any consequences on the validity of the function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran npm test.

- [x] Test getThresholdHistory
- [x] Test other verification functions exposed through the sdk