### PR TITLE
fix: sdk proposal duplicates and ipfs

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plopmenz/diamond-governance-sdk",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@plopmenz/diamond-governance-sdk",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plopmenz/diamond-governance-sdk",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@plopmenz/diamond-governance-sdk",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plopmenz/diamond-governance-sdk",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "description": "SDK for Diamond Governance, a ERC-2535 DAO bridge.",
   "main": "dist/sdk/index.js",
   "typings": "dist/sdk/index.d.ts",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plopmenz/diamond-governance-sdk",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "SDK for Diamond Governance, a ERC-2535 DAO bridge.",
   "main": "dist/sdk/index.js",
   "typings": "dist/sdk/index.d.ts",

--- a/sdk/src/sugar/proposal-cache.ts
+++ b/sdk/src/sugar/proposal-cache.ts
@@ -41,9 +41,9 @@ export class ProposalCache {
      * @param until Fill the cache until this index (exclusive)
      */
     private async FillCacheUntil(until : number) {
-        while (this.proposals.length < until) {
+        for (let i = 0; i < until; i++) {
             const prop = await this.getProposal(this.proposals.length);
-            this.proposals.push(prop);
+            this.proposals[i] = prop;
         }
     }
 

--- a/sdk/src/sugar/proposal-cache.ts
+++ b/sdk/src/sugar/proposal-cache.ts
@@ -41,8 +41,8 @@ export class ProposalCache {
      * @param until Fill the cache until this index (exclusive)
      */
     private async FillCacheUntil(until : number) {
-        for (let i = 0; i < until; i++) {
-            const prop = await this.getProposal(this.proposals.length);
+        for (let i = this.proposals.length; i < until; i++) {
+            const prop = await this.getProposal(i);
             this.proposals[i] = prop;
         }
     }

--- a/utils/ipfsHelper.ts
+++ b/utils/ipfsHelper.ts
@@ -48,8 +48,11 @@ export async function getFromIpfs(hash: string): Promise<any> {
   }
   
   const config = {
-    method: "GET",
-    url: "https://ipfs.io/ipfs/" + hash,
+    method: "POST",
+    url: "https://ipfs-0.aragon.network/api/v0/cat?arg=" + hash,
+    headers: {
+      "X-API-KEY": "b477RhECf8s8sdM7XrkLBs2wHc4kCMwpbcFC55Kt" // Publicly known Aragon IPFS node API key
+    },
   };
   
   const res = await axios(config);


### PR DESCRIPTION
# Description

SDK proposals wont generate duplicates anymore. This was possible by firing multiple events which easily could generate a race condition.
IPFS get now also uses Aragon's IPFS node, as ipfs.io gateway takes a while to index new IPFS addition sometimes (or Aragon is slow in broadcasting this to the network).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Diamond Governance Demo and dao-webapp.