### PR TITLE
feat: sdk update signer or address

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -14,6 +14,20 @@ export class DiamondGovernanceClient {
         this.sugar = new DiamondGovernanceSugar(this.pure);
         this.verification = new VerificationSugar(this.sugar, _signer);
     }
+
+    public Update(_pluginAddress : string, _signer : Signer) {
+        this.pure = new DiamondGovernancePure(_pluginAddress, _signer);
+        this.sugar = new DiamondGovernanceSugar(this.pure);
+        this.verification = new VerificationSugar(this.sugar, _signer);
+    }
+
+    public UpdateAddress(_pluginAddress : string) {
+        this.Update(_pluginAddress, this.pure.signer);
+    }
+
+    public UpdateSigner(_signer : Signer) {
+        this.Update(this.pure.pluginAddress, _signer);
+    }
 }
 
 export * from "../generated/client";


### PR DESCRIPTION
# Description

Allows users of the sdk to update the diamond address and signer while keeping the client reference. This comes in useful in case the project uses multiple networks or multiple diamonds on the same network. It also provides a solution for initialization with a dummy signer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
