### PR TITLE
Minor rewarding rework

### DIFF
--- a/contracts/facets/other/secureseco/searchseco/ISearchSECORewardingFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/ISearchSECORewardingFacet.sol
@@ -12,8 +12,8 @@ pragma solidity ^0.8.0;
 interface ISearchSECORewardingFacet {
     /// @notice Rewards the user for submitting new hashes
     /// @param _toReward The address of the user to reward
-    /// @param _hashCount The number of new hashes the user has submitted
-    /// @param _nonce A nonce
+    /// @param _hashCount The (new) total number of hashes the user has submitted
+    /// @param _nonce A nonce, the current number of hashes the user has submitted
     /// @param _proof The proof that the user received from the server
     function rewardMinerForHashes(
         address _toReward,
@@ -49,16 +49,18 @@ interface ISearchSECORewardingFacet {
     function getMiningRewardPoolPayoutRatio() external view returns (uint);
 
     /// @notice Sets the percentage of the mining pool that is paid out to the miner (per hash).
-    /// @dev Stores the devaluation factor as a quad float fraction 
+    /// @dev Stores the devaluation factor as a quad float fraction
     /// @param _miningRewardPoolPayoutRatio The new ratio (in 18 decimals)
-    function setMiningRewardPoolPayoutRatio(uint _miningRewardPoolPayoutRatio) external;
+    function setMiningRewardPoolPayoutRatio(
+        uint _miningRewardPoolPayoutRatio
+    ) external;
 
     /// @notice Returns the devaluation factor for hashes
     /// @return The devaluation factor (in 18 decimals precision)
     function getHashDevaluationFactor() external view returns (uint);
 
     /// @notice Sets the devaluation factor for hashes
-    /// @dev Stores the devaluation factor as a quad float fraction 
+    /// @dev Stores the devaluation factor as a quad float fraction
     /// @param _hashDevaluationFactor The new devaluation factor (in 18 decimals)
     function setHashDevaluationFactor(uint _hashDevaluationFactor) external;
 }

--- a/contracts/facets/other/secureseco/searchseco/SearchSECORewardingFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/SearchSECORewardingFacet.sol
@@ -96,26 +96,38 @@ contract SearchSECORewardingFacet is
             "Proof is not valid"
         );
 
-        // Make sure that the hashCount is equal
+        // Make sure that the nonce is equal to the CURRENT hashCount
         require(
             s.hashCount[_toReward] == _nonce,
             "Hash count does not match with nonce"
         );
 
-        s.hashCount[_toReward] += _hashCount;
+        require(
+            _hashCount > _nonce,
+            "New hash count must be higher than current hash count"
+        );
+
+        // Update (overwrite) the hash count for the given address
+        s.hashCount[_toReward] = _hashCount;
 
         require(
             _repFrac >= 0 && _repFrac <= 1_000_000,
             "REP fraction must be between 0 and 1_000_000"
         );
 
+        // The difference between the nonce and the TOTAL hash count is the amount of NEW hashes mined
+        uint actualHashCount = _hashCount - _nonce;
+
         // Calculate the reward
         // 1. Split number of hashes up according to the given "repFrac"
-        bytes16 hashCountQuad = ABDKMathQuad.fromUInt(_hashCount);
+        bytes16 hashCountQuad = ABDKMathQuad.fromUInt(actualHashCount);
         // This is the number of hashes for the REP reward, the rest is for the coin reward
         bytes16 numHashDivided = ABDKMathQuad.mul(
             hashCountQuad,
-            ABDKMathQuad.div(ABDKMathQuad.fromUInt(_repFrac), ABDKMathQuad.fromUInt(1_000_000))
+            ABDKMathQuad.div(
+                ABDKMathQuad.fromUInt(_repFrac),
+                ABDKMathQuad.fromUInt(1_000_000)
+            )
         ); // div by 1_000_000 to get fraction
 
         // 2. Calculate the reputation reward by multiplying the fraction
@@ -125,7 +137,12 @@ contract SearchSECORewardingFacet is
             ABDKMathQuad.fromUInt(s.hashReward)
         );
         // Multiply for inflation
-        repReward = ABDKMathQuad.mul(IRewardMultiplierFacet(address(this)).getMultiplierQuad("inflation"), repReward);
+        repReward = ABDKMathQuad.mul(
+            IRewardMultiplierFacet(address(this)).getMultiplierQuad(
+                "inflation"
+            ),
+            repReward
+        );
 
         // 3. Calculate the coin reward = 1 - (1 - miningRewardPoolPayoutRatio) ^ coinFrac
         // (don't mind the variable name, this is to minimize the amount of variables used)
@@ -223,7 +240,9 @@ contract SearchSECORewardingFacet is
         // Cast from quad float to dec18
         return
             LibABDKHelper.to18DecimalsQuad(
-                LibSearchSECORewardingStorage.getStorage().miningRewardPoolPayoutRatio
+                LibSearchSECORewardingStorage
+                    .getStorage()
+                    .miningRewardPoolPayoutRatio
             );
     }
 
@@ -235,12 +254,7 @@ contract SearchSECORewardingFacet is
     }
 
     /// @inheritdoc ISearchSECORewardingFacet
-    function getHashDevaluationFactor()
-        external
-        view
-        override
-        returns (uint)
-    {
+    function getHashDevaluationFactor() external view override returns (uint) {
         // Cast from quad float to dec18
         return
             LibABDKHelper.to18DecimalsQuad(
@@ -259,7 +273,10 @@ contract SearchSECORewardingFacet is
         uint _miningRewardPoolPayoutRatio
     ) internal {
         // No need to waste gas checking >= 0, since it's uint
-        require(_miningRewardPoolPayoutRatio <= 1e18, "Error: invalid mining reward pool payout ratio");
+        require(
+            _miningRewardPoolPayoutRatio <= 1e18,
+            "Error: invalid mining reward pool payout ratio"
+        );
         // Cast from dec18 to quad float
         LibSearchSECORewardingStorage
             .getStorage()
@@ -268,13 +285,13 @@ contract SearchSECORewardingFacet is
         );
     }
 
-    function _setHashDevaluationFactor(
-        uint _hashDevaluationFactor
-    ) internal {
+    function _setHashDevaluationFactor(uint _hashDevaluationFactor) internal {
         // Cast from uint to quad float, don't multiply or divide by anything.
         // This number is used as is to divide the number of hashes by.
         LibSearchSECORewardingStorage
             .getStorage()
-            .hashDevaluationFactor = ABDKMathQuad.fromUInt(_hashDevaluationFactor);
+            .hashDevaluationFactor = ABDKMathQuad.fromUInt(
+            _hashDevaluationFactor
+        );
     }
 }


### PR DESCRIPTION
# Description

The problem with our rewarding system is that we do not have access to the amount of **new** hashes someone has mined, we only have access to the *total* amount of hashes.

That is why I'm proposing the following change: in SearchSECORewardingFacet.rewardMinerForHashes, the _hashCount now represents the new *total* amount of hashes someone has mined, instead of simply the amount of new hashes someone mined. We then overwrite their hashCount in the storage with that number, calculate the difference between that number and the nonce: this is the amount of new hashes that have been mined since the previous transaction. After that, business is as usual.

.
.
.

TS;DR (Too Short, Didn't Read)

In the tangled maze of the intricacies that comprise our reward system, we find ourselves confronted by a significant, indeed nearly insurmountable, conundrum: we are decidedly unable, by the cruel hand of fate or some ill-conceived system design, to ascertain the quantity of freshly excavated, gleaming, newborn hashes that a miner may have successfully extracted from the rocky veins of the computational substrate. Our purview, limited as it tragically is, extends solely and exclusively to the aggregated, all-encompassing sum of hashes, a figure that encapsulates both the old and the new in an indistinguishable, monolithic whole.

Given the dire straits we find ourselves in, I am moved to advocate a deviation, a recalibration of sorts, that takes us off the well-worn path we have thus far tread. In this envisioned restructuring, our venerated function, SearchSECORewardingFacet.rewardMinerForHashes, is subjected to a radical transformation. The parameter, _hashCount, heretofore representative of the sum total of freshly unearthed hashes - their virgin gleam yet untarnished by time - will, under this new regime, signify something subtly yet profoundly different: the cumulative, comprehensive totality of hashes that a miner has coaxed into existence.

By implementing this modification, we effectively overwrite their standing hashCount in the storage, replacing it with this new, greater value. This act enables us to discern the difference between this freshly updated total and the nonce. Through this difference, we arrive at the elusive figure we have been yearning for: the quantity of virgin, unspoiled hashes mined since the latest transaction. Having achieved this, we are then free to revert to the traditional, the conventional, the familiar - business as usual, as it were, in the grand game of hashes.

## Type of change

Enhancement

# How Has This Been Tested?

Extended the `SearchSECORewarding.should reward for hashes/mining properly` test.

