### PR TITLE
fix: sdk publish action version

### DIFF
--- a/.github/workflows/sdk-publish-pipeline.yml
+++ b/.github/workflows/sdk-publish-pipeline.yml
@@ -10,7 +10,7 @@ defaults:
 
 env:
   NODE_VERSION: 18.x
-  unit-tests: ${{ github.event.inputs.js || true }}
+  npm-publish: ${{ github.event.inputs.js || true }}
 
 jobs:
   install-dependencies:
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
     
-  unit-tests:
+  npm-publish:
     runs-on: ubuntu-latest
     needs: install-dependencies
     steps:
@@ -53,8 +53,9 @@ jobs:
         run: npm run generate-sdk
       - name: Enter sdk directory
         run: cd sdk
-      - name: Increment npm package version
-        run: npm version minor
+      # Incrementing version should be done in a GitHub commit, otherwise the the package.json in GitHub will not be up to date
+      # - name: Increment npm package version
+      #   run: npm version minor --no-git-tag-version
       - name: Compile package
         run: tsc --declaration
       - name: Publish

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plopmenz/diamond-governance-sdk",
-  "version": "0.1.33",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@plopmenz/diamond-governance-sdk",
-      "version": "0.1.33",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plopmenz/diamond-governance-sdk",
-  "version": "0.1.33",
+  "version": "0.2.0",
   "description": "SDK for Diamond Governance, a ERC-2535 DAO bridge.",
   "main": "dist/sdk/index.js",
   "typings": "dist/sdk/index.d.ts",


### PR DESCRIPTION
# Description

Removed the version increment from the npm publish GitHub action. This would result in version being incremented locally in the GitHub action, but increment is not committed to the repository, so in case the version is not incremented before next release, this will result in trying to publish the same version tag. The maintainers are now expected to increment the version of the sdk package before creating a release if a sdk update is wanted. This also has the advantage of more refined version control, with also the option of not creating a sdk update on certain releases if wanted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)