### PR TITLE
fix: unit test main push

### DIFF
--- a/.github/workflows/unit-test-pipeline.yml
+++ b/.github/workflows/unit-test-pipeline.yml
@@ -9,6 +9,9 @@ on:
         default: true
         required: false
 
+  push:
+    # Do verify main is stable
+    branches: [ "main" ]
   pull_request:
     # Pull requests to main should only be done from dev
     branches: [ "dev" ]
@@ -19,7 +22,7 @@ defaults:
 
 env:
   NODE_VERSION: 18.x
-  unit-tests: ${{ github.event.inputs.js || true }}
+  unit-tests: ${{ github.event.inputs.test || true }}
 
 jobs:
   install-dependencies:


### PR DESCRIPTION
# Description

Add unit test run on main push, to verify all tests are passing indeed. Under normal conditions it should be impossible for them to fail, as main should only be merged from dev and tests passing is a requirement to merge to dev. Main being stable is high priority though, so running the tests again to be absolutely sure is worth it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)