### PR TITLE
fix: removed duplicate to 18 decimals

### DIFF
--- a/contracts/facets/other/secureseco/searchseco/SearchSECORewardingFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/SearchSECORewardingFacet.sol
@@ -148,7 +148,7 @@ contract SearchSECORewardingFacet is
         );
 
         return (
-            LibABDKHelper.to18DecimalsQuad(repReward),
+            ABDKMathQuad.toUInt(repReward),
             ABDKMathQuad.toUInt(coinReward)
         );
     }


### PR DESCRIPTION
# Description

Super Simple Stupid mistake (SSS rarity). Removed to18Decimals on the repReward, this is inherent to the repReward because it's already been multiplied by the hashReward (which is 18 decimals).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing tests were already present, although none tested this result somehow. So I added this to the Test_SearchSECORewarding.ts suite,
