### PR TITLE
fix: reward multiplier settings more user friendly

### DIFF
--- a/contracts/facets/multiplier/IRewardMultiplierFacet.sol
+++ b/contracts/facets/multiplier/IRewardMultiplierFacet.sol
@@ -31,11 +31,11 @@ abstract contract IRewardMultiplierFacet {
     }
 
     struct LinearParams {
-        bytes16 slope;
+        bytes16 slope; // 18 dec
     }
 
     struct ExponentialParams {
-        bytes16 base;
+        bytes16 base; // 18 dec
     }
 
     /// @notice This function applies a multiplier to a number while keeping the most precision
@@ -83,15 +83,13 @@ abstract contract IRewardMultiplierFacet {
         string memory _name,
         uint _startBlock,
         uint _initialAmount,
-        uint _slopeN,
-        uint _slopeD
+        uint _slope // 18 dec
     ) external virtual;
 
     function setMultiplierTypeExponential(
         string memory _name,
         uint _startBlock,
         uint _initialAmount,
-        uint _baseN,
-        uint _baseD
+        uint _base // 18 dec
     ) external virtual;
 }

--- a/contracts/facets/multiplier/RewardMultiplierFacet.sol
+++ b/contracts/facets/multiplier/RewardMultiplierFacet.sol
@@ -28,8 +28,7 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
         string name;
         uint startBlock;
         uint initialAmount;
-        uint slopeN;
-        uint slopeD;
+        uint slope; // 18dec
     }
 
     /// @inheritdoc IFacet
@@ -43,8 +42,7 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
             _initParams.name,
             _initParams.startBlock,
             _initParams.initialAmount,
-            _initParams.slopeN,
-            _initParams.slopeD
+            _initParams.slope
         );
         registerInterface(type(IRewardMultiplierFacet).interfaceId);
     }
@@ -117,15 +115,13 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
         string memory _name,
         uint _startBlock,
         uint _initialAmount,
-        uint _slopeN,
-        uint _slopeD
+        uint _slope
     ) external override auth(UPDATE_MULTIPLIER_TYPE_MEMBER_PERMISSION_ID) {
         _setMultiplierTypeLinear(
             _name,
             _startBlock,
             _initialAmount,
-            _slopeN,
-            _slopeD
+            _slope
         );
     }
 
@@ -134,15 +130,13 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
         string memory _name,
         uint _startBlock,
         uint _initialAmount,
-        uint _baseN,
-        uint _baseD
+        uint _base
     ) external override auth(UPDATE_MULTIPLIER_TYPE_MEMBER_PERMISSION_ID) {
         _setMultiplierTypeExponential(
             _name,
             _startBlock,
             _initialAmount,
-            _baseN,
-            _baseD
+            _base
         );
     }
 
@@ -164,8 +158,7 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
         string memory _name,
         uint _startBlock,
         uint _initialAmount,
-        uint _slopeN,
-        uint _slopeD
+        uint _slope
     ) internal {
         LibRewardMultiplierStorage.Storage
             storage s = LibRewardMultiplierStorage.getStorage();
@@ -174,20 +167,16 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
             LibABDKHelper.from18DecimalsQuad(_initialAmount),
             MultiplierType.LINEAR
         );
-        bytes16 _slope = ABDKMathQuad.div(
-            ABDKMathQuad.fromUInt(_slopeN),
-            ABDKMathQuad.fromUInt(_slopeD)
-        );
+        bytes16 _slopeQuad = LibABDKHelper.from18DecimalsQuad(_slope);
 
-        s.linearParams[_name] = LinearParams(_slope);
+        s.linearParams[_name] = LinearParams(_slopeQuad);
     }
 
     function _setMultiplierTypeExponential(
         string memory _name,
         uint _startBlock,
         uint _initialAmount,
-        uint _baseN,
-        uint _baseD
+        uint _base
     ) internal {
         LibRewardMultiplierStorage.Storage
             storage s = LibRewardMultiplierStorage.getStorage();
@@ -197,10 +186,7 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
             MultiplierType.EXPONENTIAL
         );
 
-        bytes16 _base = ABDKMathQuad.div(
-            ABDKMathQuad.fromUInt(_baseN),
-            ABDKMathQuad.fromUInt(_baseD)
-        );
-        s.exponentialParams[_name] = ExponentialParams(_base);
+        bytes16 _baseQuad = LibABDKHelper.from18DecimalsQuad(_base);
+        s.exponentialParams[_name] = ExponentialParams(_baseQuad);
     }
 }

--- a/scripts/Deploy.ts
+++ b/scripts/Deploy.ts
@@ -128,8 +128,7 @@ async function main() {
     name: "inflation",
     startBlock: await owner.provider?.getBlockNumber(),
     initialAmount: BigNumber.from(10).pow(18), // dec18 = 1
-    slopeN: 0,
-    slopeD: 1,
+    slope: 0,
   };
   const ABCConfigureFacetSettings = {
     marketMaker: monetaryTokenDeployer.deployedContracts.MarketMaker,

--- a/test/Test_ERC20TimeClaimable.ts
+++ b/test/Test_ERC20TimeClaimable.ts
@@ -46,8 +46,7 @@ async function getClient() {
     name: "inflation",
     startBlock: await owner.provider?.getBlockNumber(),
     initialAmount: DECIMALS_18,
-    slopeN: 0,
-    slopeD: 1,
+    slope: 0,
   };
   const cut : DiamondCut[] = [
       await DiamondCut.All(diamondGovernance.GovernanceERC20Facet, [GovernanceERC20FacetSettings]),

--- a/test/Test_RewardMultiplier.ts
+++ b/test/Test_RewardMultiplier.ts
@@ -36,8 +36,7 @@ async function getClient() {
     name: "inflation",
     startBlock: await owner.provider?.getBlockNumber(),
     initialAmount: 1,
-    slopeN: 1,
-    slopeD: 1,
+    slope: to18Decimal("0"),
   };
   const cut: DiamondCut[] = [
     await DiamondCut.All(diamondGovernance.RewardMultiplierFacet, [
@@ -64,11 +63,11 @@ const INITIAL_AMOUNT = 378303588.384; // Never used except to calculate the 18 d
 const INITIAL_AMOUNT_18 = to18Decimal(INITIAL_AMOUNT.toString());
 const MAX_BLOCKS_PASSED = 1000;
 
-const SLOPE_N = 1001;
-const SLOPE_D = 1000;
+const SLOPE = 1.001;
+const SLOPE_18 = to18Decimal(SLOPE.toString());
 
-const BASE_N = 1005;
-const BASE_D = 1000;
+const BASE = 1.005;
+const BASE_18 = to18Decimal(BASE.toString());
 
 const BASE_REWARD = 1234.56; // Never used except to calculate the 18 decimal version
 const BASE_REWARD_18 = to18Decimal(BASE_REWARD.toString());
@@ -115,8 +114,7 @@ describe("RewardMultiplier", function () {
       "nonsense",
       pastBlock,
       INITIAL_AMOUNT_18,
-      SLOPE_N,
-      SLOPE_D
+      SLOPE_18,
     );
     const multiplierAfterLinear = await IRewardMultiplierFacet.getMultiplier(
       "nonsense"
@@ -144,8 +142,7 @@ describe("RewardMultiplier", function () {
       "nonsense",
       pastBlock,
       INITIAL_AMOUNT_18,
-      BASE_N,
-      BASE_D
+      BASE_18,
     );
     const multiplierAfterExponential =
       await IRewardMultiplierFacet.getMultiplier("nonsense");
@@ -177,8 +174,7 @@ describe("RewardMultiplier", function () {
       "nonsense",
       pastBlock,
       INITIAL_AMOUNT_18,
-      BASE_N,
-      BASE_D
+      BASE_18
     );
     const multipliedReward = await IRewardMultiplierFacet.applyMultiplier(
       "nonsense",
@@ -197,7 +193,7 @@ describe("RewardMultiplier", function () {
 });
 
 const calculateLinearGrowth = (blocksPassed: number): BigNumber => {
-  const { amount, exponent: numShifted } = tenFoldUntilLimit(SLOPE_N / SLOPE_D);
+  const { amount, exponent: numShifted } = tenFoldUntilLimit(SLOPE);
   const growth = BigNumber.from(amount)
     .mul(blocksPassed)
     .mul(10 ** (18 - numShifted));
@@ -205,14 +201,14 @@ const calculateLinearGrowth = (blocksPassed: number): BigNumber => {
 };
 
 const calculateExponentialGrowth = (exponent: number): BigNumber => {
-  const { amount, exponent: numShifted } = tenFoldUntilLimit(BASE_N / BASE_D);
+  const { amount, exponent: numShifted } = tenFoldUntilLimit(BASE);
   const base = BigNumber.from(amount); // Needs Math.round due to rounding errors with division
   const growth = base.pow(exponent).mul(INITIAL_AMOUNT_18);
   return growth.div(BigNumber.from(10 ** numShifted).pow(exponent));
 };
 
 const calculateExponentialAppliedMultiplier = (exponent: number): BigNumber => {
-  const { amount, exponent: numShifted } = tenFoldUntilLimit(BASE_N / BASE_D);
+  const { amount, exponent: numShifted } = tenFoldUntilLimit(BASE);
   const base = BigNumber.from(amount); // Needs Math.round due to rounding errors with division
   const growth = base
     .pow(exponent)

--- a/test/Test_SearchSECORewardingFacet.ts
+++ b/test/Test_SearchSECORewardingFacet.ts
@@ -80,8 +80,7 @@ async function getClient() {
     name: "inflation",
     startBlock: await owner.provider?.getBlockNumber(),
     initialAmount: DECIMALS_18,
-    slopeN: 0,
-    slopeD: 1,
+    slope: 0,
   };
   const cut: DiamondCut[] = [
     await DiamondCut.All(diamondGovernance.SearchSECORewardingFacet, [


### PR DESCRIPTION
# Description

Reward multiplier now takes a single variable (18 decimals), instead of a numerator and denominator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
By my eyes and ``npm test``.
