### PR TITLE
feat: ABC benchmark test

### DIFF
--- a/contracts/facets/token/ERC20/monetary-token/ABC/core/SimpleHatch.sol
+++ b/contracts/facets/token/ERC20/monetary-token/ABC/core/SimpleHatch.sol
@@ -92,6 +92,7 @@ contract SimpleHatch is PluginStandalone, Modifiers {
     }
 
     function getReward(uint256 _contribution) internal virtual returns (uint256) {
+        // _contribution * (initialPrice / 1e18)
         return ABDKMathQuad.toUInt(ABDKMathQuad.mul(ABDKMathQuad.fromUInt(_contribution), LibABDKHelper.from18DecimalsQuad(_state.params.initialPrice)));
     }
 }

--- a/scripts/Deploy.ts
+++ b/scripts/Deploy.ts
@@ -33,12 +33,12 @@ async function main() {
     curveParameters: {
       theta: 0.05 * 10**6, // 5%
       friction: 0.01 * 10**6, // 1%
-      reserveRatio: 0.2 * 10**6, // 20%
+      reserveRatio: 0.5 * 10**6, // 50%
     },
     hatchParameters: {
-      initialPrice: wei.mul(1),
-      minimumRaise: wei.mul(1),
-      maximumRaise: wei.mul(1),
+      initialPrice: to18Decimal("10000"),
+      minimumRaise: ether.mul(10),
+      maximumRaise: ether.mul(20),
       hatchDeadline: now() + 24 * hours,
     },
     vestingSchedule: {


### PR DESCRIPTION
# Description

Added a test to be able to benchmark how the ABC curve progresses after a certain amount of DAI has been used to mint tokens. This will help in deciding the production variables we want to use to launch on Polygon mainnet. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
