### PR TITLE
chore: expose queryTreasuryRatio + rename

### DIFF
--- a/contracts/facets/other/secureseco/searchseco/ISearchSECOMonetizationFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/ISearchSECOMonetizationFacet.sol
@@ -24,4 +24,12 @@ interface ISearchSECOMonetizationFacet {
     /// @notice Updates the cost of a hash (in the context of SearchSECO)
     /// @param _hashCost The new cost of a hash
     function setHashCost(uint _hashCost) external;
+
+    /// @notice Retrieve the current treasury ratio. This is the percentage of the hashcost that goes to the treasury.
+    /// @return uint32 The current treasury ratio
+    function getQueryTreasuryRatio() external view returns (uint32);
+
+    /// @notice Updates the treasury ratio
+    /// @param _queryTreasuryRatio The new treasury ratio
+    function setQueryTreasuryRatio(uint32 _queryTreasuryRatio) external;
 }

--- a/contracts/facets/other/secureseco/searchseco/ISearchSECOMonetizationFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/ISearchSECOMonetizationFacet.sol
@@ -27,9 +27,9 @@ interface ISearchSECOMonetizationFacet {
 
     /// @notice Retrieve the current treasury ratio. This is the percentage of the hashcost that goes to the treasury.
     /// @return uint32 The current treasury ratio
-    function getQueryTreasuryRatio() external view returns (uint32);
+    function getQueryMiningRewardPoolRatio() external view returns (uint32);
 
     /// @notice Updates the treasury ratio
-    /// @param _queryTreasuryRatio The new treasury ratio
-    function setQueryTreasuryRatio(uint32 _queryTreasuryRatio) external;
+    /// @param _queryMiningRewardPoolRatio The new treasury ratio
+    function setQueryMiningRewardPoolRatio(uint32 _queryMiningRewardPoolRatio) external;
 }

--- a/contracts/facets/other/secureseco/searchseco/SearchSECOMonetizationFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/SearchSECOMonetizationFacet.sol
@@ -31,7 +31,7 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
 
     struct SearchSECOMonetizationFacetInitParams {
         uint256 hashCost;
-        uint32 treasuryRatio;
+        uint32 queryTreasuryRatio; // ppm
     }
 
     /// @inheritdoc IFacet
@@ -45,7 +45,7 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
         SearchSECOMonetizationFacetInitParams memory _params
     ) public virtual {
         LibSearchSECOMonetizationStorage.getStorage().hashCost = _params.hashCost;
-        LibSearchSECOMonetizationStorage.getStorage().treasuryRatio = _params.treasuryRatio;
+        LibSearchSECOMonetizationStorage.getStorage().queryTreasuryRatio = _params.queryTreasuryRatio;
         
         registerInterface(type(ISearchSECOMonetizationFacet).interfaceId);
     }
@@ -73,7 +73,7 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
         );
 
         // Calculate the amount of tokens that go to the treasury and the mining reward pool
-        uint ratio = s.treasuryRatio;
+        uint ratio = s.queryTreasuryRatio;
 
         uint totalPayout = s.hashCost * _amount;
         uint toMiningRewardPool = _applyRatioCeiled(totalPayout, ratio);
@@ -99,5 +99,15 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
     /// @inheritdoc ISearchSECOMonetizationFacet
     function setHashCost(uint _hashCost) external virtual override auth(UPDATE_HASH_COST_MAPPING_PERMISSION_ID) {
         LibSearchSECOMonetizationStorage.getStorage().hashCost = _hashCost;
+    }
+
+    /// @inheritdoc ISearchSECOMonetizationFacet
+    function getQueryTreasuryRatio() external view virtual override returns (uint32) {
+        return LibSearchSECOMonetizationStorage.getStorage().queryTreasuryRatio;
+    }
+
+    /// @inheritdoc ISearchSECOMonetizationFacet
+    function setQueryTreasuryRatio(uint32 _queryTreasuryRatio) external virtual override auth(UPDATE_HASH_COST_MAPPING_PERMISSION_ID) {
+        LibSearchSECOMonetizationStorage.getStorage().queryTreasuryRatio = _queryTreasuryRatio;
     }
 }

--- a/contracts/facets/other/secureseco/searchseco/SearchSECOMonetizationFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/SearchSECOMonetizationFacet.sol
@@ -31,7 +31,7 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
 
     struct SearchSECOMonetizationFacetInitParams {
         uint256 hashCost;
-        uint32 queryTreasuryRatio; // ppm
+        uint32 queryMiningRewardPoolRatio; // ppm
     }
 
     /// @inheritdoc IFacet
@@ -45,7 +45,7 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
         SearchSECOMonetizationFacetInitParams memory _params
     ) public virtual {
         LibSearchSECOMonetizationStorage.getStorage().hashCost = _params.hashCost;
-        LibSearchSECOMonetizationStorage.getStorage().queryTreasuryRatio = _params.queryTreasuryRatio;
+        LibSearchSECOMonetizationStorage.getStorage().queryMiningRewardPoolRatio = _params.queryMiningRewardPoolRatio;
         
         registerInterface(type(ISearchSECOMonetizationFacet).interfaceId);
     }
@@ -73,7 +73,7 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
         );
 
         // Calculate the amount of tokens that go to the treasury and the mining reward pool
-        uint ratio = s.queryTreasuryRatio;
+        uint ratio = s.queryMiningRewardPoolRatio;
 
         uint totalPayout = s.hashCost * _amount;
         uint toMiningRewardPool = _applyRatioCeiled(totalPayout, ratio);
@@ -102,12 +102,12 @@ contract SearchSECOMonetizationFacet is AuthConsumer, ISearchSECOMonetizationFac
     }
 
     /// @inheritdoc ISearchSECOMonetizationFacet
-    function getQueryTreasuryRatio() external view virtual override returns (uint32) {
-        return LibSearchSECOMonetizationStorage.getStorage().queryTreasuryRatio;
+    function getQueryMiningRewardPoolRatio() external view virtual override returns (uint32) {
+        return LibSearchSECOMonetizationStorage.getStorage().queryMiningRewardPoolRatio;
     }
 
     /// @inheritdoc ISearchSECOMonetizationFacet
-    function setQueryTreasuryRatio(uint32 _queryTreasuryRatio) external virtual override auth(UPDATE_HASH_COST_MAPPING_PERMISSION_ID) {
-        LibSearchSECOMonetizationStorage.getStorage().queryTreasuryRatio = _queryTreasuryRatio;
+    function setQueryMiningRewardPoolRatio(uint32 _queryMiningRewardPoolRatio) external virtual override auth(UPDATE_HASH_COST_MAPPING_PERMISSION_ID) {
+        LibSearchSECOMonetizationStorage.getStorage().queryMiningRewardPoolRatio = _queryMiningRewardPoolRatio;
     }
 }

--- a/contracts/libraries/storage/LibSearchSECOMonetizationStorage.sol
+++ b/contracts/libraries/storage/LibSearchSECOMonetizationStorage.sol
@@ -15,7 +15,7 @@ library LibSearchSECOMonetizationStorage {
         uint256 hashCost;
 
         /// @notice Defines the ratio between what goes to the treasury and what goes to rewarding the miners.
-        uint32 treasuryRatio; // ppm
+        uint32 queryTreasuryRatio; // ppm
     }
 
     function getStorage() internal pure returns (Storage storage ds) {

--- a/contracts/libraries/storage/LibSearchSECOMonetizationStorage.sol
+++ b/contracts/libraries/storage/LibSearchSECOMonetizationStorage.sol
@@ -15,7 +15,7 @@ library LibSearchSECOMonetizationStorage {
         uint256 hashCost;
 
         /// @notice Defines the ratio between what goes to the treasury and what goes to rewarding the miners.
-        uint32 queryTreasuryRatio; // ppm
+        uint32 queryMiningRewardPoolRatio; // ppm
     }
 
     function getStorage() internal pure returns (Storage storage ds) {

--- a/scripts/Deploy.ts
+++ b/scripts/Deploy.ts
@@ -113,7 +113,7 @@ async function main() {
   };
   const SearchSECOMonetizationFacetSettings = {
     hashCost: gwei.mul(1),
-    treasuryRatio: 0.2 * 10**6, // 20%
+    queryTreasuryRatio: 0.2 * 10**6, // 20%
   };
   const SearchSECORewardingFacetSettings = {
     signer: owner.address,

--- a/scripts/Deploy.ts
+++ b/scripts/Deploy.ts
@@ -113,7 +113,7 @@ async function main() {
   };
   const SearchSECOMonetizationFacetSettings = {
     hashCost: gwei.mul(1),
-    queryTreasuryRatio: 0.2 * 10**6, // 20%
+    queryMiningRewardPoolRatio: 0.2 * 10**6, // 20%
   };
   const SearchSECORewardingFacetSettings = {
     signer: owner.address,

--- a/test/Test_SearchSECORewardingFacet.ts
+++ b/test/Test_SearchSECORewardingFacet.ts
@@ -61,7 +61,7 @@ async function getClient() {
   };
   const SearchSECOMonetizationFacetSettings = {
     hashCost: HASH_COST,
-    treasuryRatio: TREASURY_RATIO,
+    queryTreasuryRatio: TREASURY_RATIO,
   };
   const MonetaryTokenFacetSettings = {
     monetaryTokenContractAddress: monetaryToken,

--- a/test/Test_SearchSECORewardingFacet.ts
+++ b/test/Test_SearchSECORewardingFacet.ts
@@ -61,7 +61,7 @@ async function getClient() {
   };
   const SearchSECOMonetizationFacetSettings = {
     hashCost: HASH_COST,
-    queryTreasuryRatio: TREASURY_RATIO,
+    queryMiningRewardPoolRatio: TREASURY_RATIO,
   };
   const MonetaryTokenFacetSettings = {
     monetaryTokenContractAddress: monetaryToken,


### PR DESCRIPTION
# Description

Expose queryTreasuryRatio variable from SearchSECO Monetization. This variable decides how much of the hash query payment goes to the treasury and how much goes to the mining reward pool.
Also renamed this from treasuryRatio, because that was too vague.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran ``npm test``.
