### PR TITLE
fix: bug where more than the pool could be requested

### DIFF
--- a/contracts/facets/token/ERC20/claiming/one-time/ERC20OneTimeVerificationRewardFacet.sol
+++ b/contracts/facets/token/ERC20/claiming/one-time/ERC20OneTimeVerificationRewardFacet.sol
@@ -91,8 +91,12 @@ contract ERC20OneTimeVerificationRewardFacet is
     /// @inheritdoc IERC20OneTimeVerificationRewardFacet
     function claimVerificationRewardAll() external virtual {
         // _claim(msg.sender);
-        IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
-            memory reward = _tokensClaimable(msg.sender);
+        (
+            IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
+                memory reward,
+            IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward[]
+                memory eachReward
+        ) = _tokensClaimable(msg.sender);
         IMintableGovernanceStructure(address(this)).mintVotingPower(
             msg.sender,
             0,
@@ -102,7 +106,7 @@ contract ERC20OneTimeVerificationRewardFacet is
             msg.sender,
             reward.coinReward
         );
-        _afterClaim(msg.sender);
+        _afterClaim(msg.sender, eachReward);
     }
 
     /// @inheritdoc IERC20OneTimeVerificationRewardFacet
@@ -135,7 +139,8 @@ contract ERC20OneTimeVerificationRewardFacet is
         _afterClaimStamp(
             msg.sender,
             stampsAt[_stampIndex].providerId,
-            stampsAt[_stampIndex].userHash
+            stampsAt[_stampIndex].userHash,
+            reward
         );
     }
 
@@ -181,6 +186,8 @@ contract ERC20OneTimeVerificationRewardFacet is
         virtual
         returns (
             IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
+                memory,
+            IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward[]
                 memory
         )
     {
@@ -203,11 +210,15 @@ contract ERC20OneTimeVerificationRewardFacet is
             address(this)
         ).getStampsAt(msg.sender, block.timestamp);
         require(_stampIndex < stampsAt.length, "Stamp index out of bound");
+        uint verificationRewardPoolBalance = IVerificationRewardPoolFacet(
+            address(this)
+        ).getVerificationRewardPool();
         return
             _tokensClaimableStamp(
                 msg.sender,
                 stampsAt[_stampIndex].providerId,
-                stampsAt[_stampIndex].userHash
+                stampsAt[_stampIndex].userHash,
+                verificationRewardPoolBalance
             );
     }
 
@@ -223,7 +234,9 @@ contract ERC20OneTimeVerificationRewardFacet is
         virtual
         returns (
             IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
-                memory reward
+                memory reward,
+            IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward[]
+                memory eachReward
         )
     {
         // Get data from storage
@@ -236,18 +249,29 @@ contract ERC20OneTimeVerificationRewardFacet is
                 0
             );
 
+        eachReward = new IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward[](
+                stampsAt.length
+            );
+
+        uint verificationRewardPoolBalance = IVerificationRewardPoolFacet(
+            address(this)
+        ).getVerificationRewardPool();
+
         for (uint i; i < stampsAt.length; ) {
             IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
                 memory rewardClaimable = _tokensClaimableStamp(
                     _claimer,
                     stampsAt[i].providerId,
-                    stampsAt[i].userHash
+                    stampsAt[i].userHash,
+                    verificationRewardPoolBalance
                 );
             if (rewardClaimable.repReward != 0) {
                 reward.repReward += rewardClaimable.repReward;
+                eachReward[i].repReward += rewardClaimable.repReward;
             }
             if (rewardClaimable.coinReward != 0) {
                 reward.coinReward += rewardClaimable.coinReward;
+                eachReward[i].coinReward += rewardClaimable.coinReward;
             }
 
             unchecked {
@@ -264,7 +288,8 @@ contract ERC20OneTimeVerificationRewardFacet is
     function _tokensClaimableStamp(
         address _claimer,
         string memory _provider,
-        string memory _stamp
+        string memory _stamp,
+        uint verificationRewardPoolBalance
     )
         internal
         view
@@ -290,9 +315,6 @@ contract ERC20OneTimeVerificationRewardFacet is
         // Amount already claimed for a unique stamp
         IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
             memory amountClaimedForStamp = s.amountClaimedForStamp[_stamp];
-        uint verificationRewardPoolBalance = IVerificationRewardPoolFacet(
-            address(this)
-        ).getVerificationRewardPool();
 
         return
             IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward(
@@ -315,7 +337,11 @@ contract ERC20OneTimeVerificationRewardFacet is
     // Copied from IERC20ClaimableFacet.sol
     /// @notice Set the amount of tokens claimed for all stamps.
     /// @param _claimer The address to check.
-    function _afterClaim(address _claimer) internal virtual {
+    function _afterClaim(
+        address _claimer,
+        IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward[]
+            memory eachReward
+    ) internal virtual {
         // Get data from storage
         SignVerification.Stamp[] memory stampsAt = VerificationFacet(
             address(this)
@@ -325,7 +351,8 @@ contract ERC20OneTimeVerificationRewardFacet is
             _afterClaimStamp(
                 _claimer,
                 stampsAt[i].providerId,
-                stampsAt[i].userHash
+                stampsAt[i].userHash,
+                eachReward[i]
             );
 
             unchecked {
@@ -341,12 +368,13 @@ contract ERC20OneTimeVerificationRewardFacet is
     function _afterClaimStamp(
         address _claimer,
         string memory _provider,
-        string memory _stamp
+        string memory _stamp,
+        IERC20OneTimeVerificationRewardFacet.OneTimeVerificationReward
+            memory reward
     ) internal virtual {
         LibERC20OneTimeVerificationRewardStorage.Storage
             storage s = LibERC20OneTimeVerificationRewardStorage.getStorage();
-        s.amountClaimedByAddressForProvider[_claimer][_provider] = s
-            .providerReward[_provider];
-        s.amountClaimedForStamp[_stamp] = s.providerReward[_provider];
+        s.amountClaimedByAddressForProvider[_claimer][_provider] = reward;
+        s.amountClaimedForStamp[_stamp] = reward;
     }
 }

--- a/contracts/facets/token/ERC20/claiming/one-time/IERC20OneTimeVerificationRewardFacet.sol
+++ b/contracts/facets/token/ERC20/claiming/one-time/IERC20OneTimeVerificationRewardFacet.sol
@@ -20,7 +20,7 @@ interface IERC20OneTimeVerificationRewardFacet {
         uint256 coinReward;
     }
 
-    function tokensClaimableVerificationRewardAll() external view returns (OneTimeVerificationReward memory);
+    function tokensClaimableVerificationRewardAll() external view returns (OneTimeVerificationReward memory, OneTimeVerificationReward[] memory);
 
     function claimVerificationRewardAll() external;
 

--- a/test/Test_VerificationRewardPool.ts
+++ b/test/Test_VerificationRewardPool.ts
@@ -186,8 +186,9 @@ describe("VerificationRewardPool", async function () {
     expect(ERC20MonetaryToken.balanceOf(daoAddress));
 
     const toClaim = await IERC20OneTimeVerificationRewardFacet.tokensClaimableVerificationRewardAll();
-    expect(toClaim[0]).to.be.equal(0);
-    expect(toClaim[1]).to.be.equal(0);
+    expect(toClaim[0][0]).to.be.equal(0);
+    expect(toClaim[0][1]).to.be.equal(0);
+    expect(toClaim[0]).to.be.deep.equal(toClaim[1][0]);
   });
   it("cap secoin reward at verification reward pool balance", async function () {
     const client = await loadFixture(getClient);


### PR DESCRIPTION
# Description

Fixed some moronic bugs in the code.

Details of the bug: basically the function to check how many tokens were claimable for verification rewards did not respect (keep track of) the verification reward pool balance over multiple stamp; it just used the same balance for every stamp.
Also each reward to the stamp is now tracked so I can set the variables for the relevant rewarded providers individually (not using the max reward, which causes people to potentially miss out on tokens).

Potentially breaking change for the front-end, as the tokensClaimable functions now returns a tuple.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Existing tests -> npm test.
Added specific test to test this behavior in Test_VerificationRewardPoolFacet.ts