### PR TITLE
chore: rename hashReward -> hashRepReward

### DIFF
--- a/contracts/facets/other/secureseco/searchseco/ISearchSECORewardingFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/ISearchSECORewardingFacet.sol
@@ -39,11 +39,11 @@ interface ISearchSECORewardingFacet {
 
     /// @notice Returns the hash reward (REP), in 18 decimals precision
     /// @return The hash reward
-    function getHashReward() external view returns (uint);
+    function getHashRepReward() external view returns (uint);
 
     /// @notice Sets the hash reward (REP)
-    /// @param _hashReward The new hash reward
-    function setHashReward(uint _hashReward) external;
+    /// @param _hashRepReward The new hash reward
+    function setHashRepReward(uint _hashRepReward) external;
 
     /// @notice Returns the signer used for signature verification
     /// @return address signer

--- a/contracts/facets/other/secureseco/searchseco/SearchSECORewardingFacet.sol
+++ b/contracts/facets/other/secureseco/searchseco/SearchSECORewardingFacet.sol
@@ -30,7 +30,7 @@ contract SearchSECORewardingFacet is
     ISearchSECORewardingFacet,
     IFacet
 {
-    // Permission used by the setHashReward function
+    // Permission used by the setHashRepReward function
     bytes32 public constant UPDATE_HASH_REWARD_PERMISSION_ID =
         keccak256("UPDATE_HASH_REWARD_PERMISSION_ID");
 
@@ -42,7 +42,7 @@ contract SearchSECORewardingFacet is
         address signer;
         uint miningRewardPoolPayoutRatio;
         uint hashDevaluationFactor;
-        uint hashReward;
+        uint hashRepReward;
     }
 
     /// @inheritdoc IFacet
@@ -61,7 +61,7 @@ contract SearchSECORewardingFacet is
         LibSearchSECORewardingStorage.Storage
             storage s = LibSearchSECORewardingStorage.getStorage();
         s.signer = _params.signer;
-        s.hashReward = _params.hashReward;
+        s.hashRepReward = _params.hashRepReward;
         _setMiningRewardPoolPayoutRatio(_params.miningRewardPoolPayoutRatio);
         _setHashDevaluationFactor(_params.hashDevaluationFactor);
 
@@ -107,7 +107,7 @@ contract SearchSECORewardingFacet is
         //    for the REP reward (calculated in step 1) to the hash reward (from storage)
         bytes16 repReward = ABDKMathQuad.mul(
             numHashDivided,
-            ABDKMathQuad.fromUInt(s.hashReward)
+            ABDKMathQuad.fromUInt(s.hashRepReward)
         );
         // Multiply for inflation
         repReward = ABDKMathQuad.mul(
@@ -228,15 +228,15 @@ contract SearchSECORewardingFacet is
     }
 
     /// @inheritdoc ISearchSECORewardingFacet
-    function getHashReward() external view virtual override returns (uint) {
-        return LibSearchSECORewardingStorage.getStorage().hashReward;
+    function getHashRepReward() external view virtual override returns (uint) {
+        return LibSearchSECORewardingStorage.getStorage().hashRepReward;
     }
 
     /// @inheritdoc ISearchSECORewardingFacet
-    function setHashReward(
-        uint _hashReward
+    function setHashRepReward(
+        uint _hashRepReward
     ) public virtual override auth(UPDATE_HASH_REWARD_PERMISSION_ID) {
-        LibSearchSECORewardingStorage.getStorage().hashReward = _hashReward;
+        LibSearchSECORewardingStorage.getStorage().hashRepReward = _hashRepReward;
     }
 
     /// @inheritdoc ISearchSECORewardingFacet

--- a/contracts/libraries/storage/LibSearchSECORewardingStorage.sol
+++ b/contracts/libraries/storage/LibSearchSECORewardingStorage.sol
@@ -15,7 +15,7 @@ library LibSearchSECORewardingStorage {
         mapping(address => uint) hashCount;
         address signer;
         /// @notice The reward that is given to a user for submitting a new hash
-        uint hashReward;
+        uint hashRepReward;
 
         /// @notice Defines the percentage of the pool that is paid out to the miner.
         bytes16 miningRewardPoolPayoutRatio; // quad float

--- a/scripts/Deploy.ts
+++ b/scripts/Deploy.ts
@@ -119,7 +119,7 @@ async function main() {
     signer: owner.address,
     miningRewardPoolPayoutRatio: to18Decimal("0.01"), // 1%
     hashDevaluationFactor: 10000, // 10000 hashes for 1% of mining reward pool
-    hashReward: to18Decimal("0.01"), // 1 SECOREP per 100 hashes
+    hashRepReward: to18Decimal("0.01"), // 1 SECOREP per 100 hashes
   };
   const MonetaryTokenFacetSettings = {
     monetaryTokenContractAddress: MonetaryToken,

--- a/test/Test_SearchSECORewardingFacet.ts
+++ b/test/Test_SearchSECORewardingFacet.ts
@@ -58,7 +58,7 @@ async function getClient() {
     signer: owner.address,
     miningRewardPoolPayoutRatio: MINING_REWARD_POOL_PAYOUT_RATIO_18,
     hashDevaluationFactor: HASH_DEVALUATION_FACTOR,
-    hashReward: HASH_REWARD,
+    hashRepReward: HASH_REWARD,
   };
   const SearchSECOMonetizationFacetSettings = {
     hashCost: HASH_COST,


### PR DESCRIPTION
# Description
Rename hashReward to hashRepReward to better reflect on its purpose.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran npm test