### PR TITLE
feat: add more get/set to rewardmultiplier

### DIFF
--- a/contracts/facets/multiplier/IRewardMultiplierFacet.sol
+++ b/contracts/facets/multiplier/IRewardMultiplierFacet.sol
@@ -95,7 +95,15 @@ abstract contract IRewardMultiplierFacet {
 
 
     // Specific get/set functions for the "inflation" multiplier, this is useful for the auto expose
-    function setInflationTimestamp(uint _inflationTimestamp) external virtual;
+    function setInflationStartTimestamp(uint _inflationStartTimestamp) external virtual;
 
-    function getInflationTimestamp() external view virtual returns (uint);
+    function getInflationStartTimestamp() external view virtual returns (uint);
+
+    function setInflationBase(uint _inflationBase) external virtual;
+
+    function getInflationBase() external view virtual returns (uint);
+
+    function setInflationInitialAmount(uint _inflationInitialAmount) external virtual;
+
+    function getInflationInitialAmount() external view virtual returns (uint);
 }

--- a/contracts/facets/multiplier/RewardMultiplierFacet.sol
+++ b/contracts/facets/multiplier/RewardMultiplierFacet.sol
@@ -142,17 +142,47 @@ contract RewardMultiplierFacet is AuthConsumer, IRewardMultiplierFacet, IFacet {
     }
 
     /// @inheritdoc IRewardMultiplierFacet
-    function setInflationTimestamp(uint _inflationTimestamp) external override auth(UPDATE_MULTIPLIER_TYPE_MEMBER_PERMISSION_ID) {
+    function setInflationStartTimestamp(uint _inflationTimestamp) external override auth(UPDATE_MULTIPLIER_TYPE_MEMBER_PERMISSION_ID) {
         LibRewardMultiplierStorage.Storage
             storage s = LibRewardMultiplierStorage.getStorage();
         s.rewardMultiplier["inflation"].startTimestamp = _inflationTimestamp;
     }
 
     /// @inheritdoc IRewardMultiplierFacet
-    function getInflationTimestamp() external view override returns (uint) {
+    function getInflationStartTimestamp() external view override returns (uint) {
         LibRewardMultiplierStorage.Storage
             storage s = LibRewardMultiplierStorage.getStorage();
         return s.rewardMultiplier["inflation"].startTimestamp;
+    }
+
+    /// @inheritdoc IRewardMultiplierFacet
+    function setInflationBase(uint _inflationBase) external override auth(UPDATE_MULTIPLIER_TYPE_MEMBER_PERMISSION_ID) {
+        LibRewardMultiplierStorage.Storage
+            storage s = LibRewardMultiplierStorage.getStorage();
+
+        bytes16 _baseQuad = LibABDKHelper.from18DecimalsQuad(_inflationBase);
+        s.exponentialParams["inflation"] = ExponentialParams(_baseQuad);
+    }
+
+    /// @inheritdoc IRewardMultiplierFacet
+    function getInflationBase() external view override returns (uint) {
+        LibRewardMultiplierStorage.Storage
+            storage s = LibRewardMultiplierStorage.getStorage();
+        return LibABDKHelper.to18DecimalsQuad(s.exponentialParams["inflation"].base);
+    }
+
+    /// @inheritdoc IRewardMultiplierFacet
+    function setInflationInitialAmount(uint _inflationInitialAmount) external override {
+        LibRewardMultiplierStorage.Storage
+            storage s = LibRewardMultiplierStorage.getStorage();
+        s.rewardMultiplier["inflation"].initialAmount = LibABDKHelper.from18DecimalsQuad(_inflationInitialAmount);
+    }
+
+    /// @inheritdoc IRewardMultiplierFacet
+    function getInflationInitialAmount() external view override returns (uint) {
+        LibRewardMultiplierStorage.Storage
+            storage s = LibRewardMultiplierStorage.getStorage();
+        return LibABDKHelper.to18DecimalsQuad(s.rewardMultiplier["inflation"].initialAmount);
     }
 
     function _setMultiplierTypeConstant(

--- a/test/Test_RewardMultiplier.ts
+++ b/test/Test_RewardMultiplier.ts
@@ -169,6 +169,22 @@ describe("RewardMultiplier", function () {
     const wrongMultiplier = calculateExponentialAppliedMultiplier(DAYS_PASSED + 1);
     expect(multipliedReward).to.be.not.approximately(wrongMultiplier, 1); // For rounding errors
   });
+  it("get/set tests", async function () {
+    const client = await loadFixture(getClient);
+    const IRewardMultiplierFacet = await client.pure.IRewardMultiplierFacet();
+
+    // test start timestamp
+    await IRewardMultiplierFacet.setInflationStartTimestamp(1234);
+    expect(await IRewardMultiplierFacet.getInflationStartTimestamp()).to.be.equal(1234);
+
+    // test initial amount
+    await IRewardMultiplierFacet.setInflationInitialAmount(1234);
+    expect(await IRewardMultiplierFacet.getInflationInitialAmount()).to.be.approximately(1234, 1);
+
+    // test base
+    await IRewardMultiplierFacet.setInflationBase(1234);
+    expect(await IRewardMultiplierFacet.getInflationBase()).to.be.approximately(1234, 1);
+  })
 });
 
 const calculateLinearGrowth = (blocksPassed: number): BigNumber => {


### PR DESCRIPTION
# Description

Added more getters/setters to RewardMultiplierFacet (+ tests).
Variables added: inflation base and inflation initial amount.
Changed variable name of inflation start timestamp.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added tests for get/set to file below.

- [ ] Test_RewardMultiplier.ts
