### PR TITLE
Feat/sdk verification blocknumber changes

### DIFF
--- a/sdk/src/verification.ts
+++ b/sdk/src/verification.ts
@@ -1,8 +1,9 @@
 import { SignVerification } from "../../typechain-types";
 import { DiamondGovernanceSugar, Stamp, VerificationThreshold } from "./sugar";
-import { ContractTransaction, BigNumber } from "ethers";
+import { ContractTransaction, BigNumber, ethers, providers } from "ethers";
 import { Signer } from "@ethersproject/abstract-signer";
 import { GetTypedContractAt } from "../../utils/contractHelper";
+import { asyncMap } from "./utils";
 
 /**
  * VerificationSugar is a class that provides methods for interacting with the verification contract.
@@ -49,7 +50,21 @@ export class VerificationSugar {
    */
   public async GetStamps(address: string): Promise<Stamp[]> {
     const verificationContract = await this.GetVerificationContract();
-    return verificationContract.getStamps(address);
+    // return verificationContract.getStamps(address);
+    const provider = this.signer.provider;
+    if (provider == null) {
+      throw new Error("No provider found");
+    }
+    // Convert every block number to a timestamp
+
+    const stamps = await verificationContract.getStamps(address);
+
+    return asyncMap(stamps, async (stamp) => {
+      stamp[2] = await asyncMap(stamp[2], async (blockNumber) => {
+        return await this.blockNumberToTimestamp(provider, blockNumber);
+      });
+      return stamp;
+    });
   }
 
   /**
@@ -59,8 +74,16 @@ export class VerificationSugar {
   public async GetThresholdHistory(): Promise<VerificationThreshold[]> {
     if (this.cache.thresholdHistory == null) {
       const verificationContract = await this.GetVerificationContract();
-      this.cache.thresholdHistory =
-        await verificationContract.getThresholdHistory();
+      const thresholdHistory = await verificationContract.getThresholdHistory();
+
+      const provider = this.signer.provider;
+      if (provider == null) {
+        throw new Error("No provider found");
+      }
+      this.cache.thresholdHistory = await asyncMap(thresholdHistory, async (threshold) => {
+        threshold[0] = await this.blockNumberToTimestamp(provider, threshold[1]);
+        return threshold;
+      });
     }
     return this.cache.thresholdHistory;
   }
@@ -160,6 +183,10 @@ export class VerificationSugar {
     return await verificationContract.unverify(providerId);
   }
 
+  /**
+   * Gets the reverify threshold (number of blocks until a user can reverify)
+   * @returns The reverify threshold in blocks
+   */
   public async GetReverifyThreshold(): Promise<BigNumber> {
     const verificationContract = await this.GetVerificationContract();
     return await verificationContract.getReverifyThreshold();
@@ -174,12 +201,19 @@ export class VerificationSugar {
   private getThresholdForBlockNumber(
     blockNumber: number,
     thresholdHistory: VerificationThreshold[]
-  ) {
+  ) : BigNumber {
     let threshold = thresholdHistory.reverse().find((threshold) => {
       return blockNumber >= threshold[0].toNumber();
     });
 
     return threshold ? threshold[1] : BigNumber.from(0);
+  }
+
+  private async blockNumberToTimestamp(
+    provider: providers.Provider,
+    blockNumber: BigNumber
+  ) : Promise<BigNumber> {
+    return BigNumber.from((await provider.getBlock(blockNumber.toNumber())).timestamp);
   }
 
 }

--- a/sdk/src/verification.ts
+++ b/sdk/src/verification.ts
@@ -59,12 +59,13 @@ export class VerificationSugar {
 
     const stamps = await verificationContract.getStamps(address);
 
-    return asyncMap(stamps, async (stamp) => {
-      stamp[2] = await asyncMap(stamp[2], async (blockNumber) => {
+    return asyncMap(stamps, async (stamp) => [
+      stamp[0],
+      stamp[1],
+      await asyncMap(stamp[2], async (blockNumber) => {
         return await this.blockNumberToTimestamp(provider, blockNumber);
-      });
-      return stamp;
-    });
+      }),
+    ]);
   }
 
   /**
@@ -80,10 +81,10 @@ export class VerificationSugar {
       if (provider == null) {
         throw new Error("No provider found");
       }
-      this.cache.thresholdHistory = await asyncMap(thresholdHistory, async (threshold) => {
-        threshold[0] = await this.blockNumberToTimestamp(provider, threshold[1]);
-        return threshold;
-      });
+      this.cache.thresholdHistory = await asyncMap(thresholdHistory, async (threshold) => [
+        await this.blockNumberToTimestamp(provider, threshold[0]),
+        threshold[1],
+      ]);
     }
     return this.cache.thresholdHistory;
   }

--- a/test/Test_Verification.ts
+++ b/test/Test_Verification.ts
@@ -78,4 +78,19 @@ describe("SignVerification", () => {
     await IVerificationFacet.setVerifyThreshold(1);
     expect(await IVerificationFacet.getVerifyThreshold()).to.equal(1);
   });
+  // This doesn't actually assert anything, just tests if the functions don't throw
+  it("sdk verification sugar tests", async () => {
+    const client = await loadFixture(getClient);
+    const [owner] = await ethers.getSigners();
+
+    // Manually verify owner with github
+    const timestamp = now();
+    const userHash =
+      "090d4910f4b4038000f6ea86644d55cb5261a1dc1f006d928dcc049b157daff8";
+    const dataHexString = await createSignature(timestamp, owner.address, userHash, owner);
+    await client.verification.Verify(owner.address, userHash, timestamp, "github", dataHexString);
+
+    await client.verification.GetThresholdHistory();
+    await client.verification.GetStamps(owner.address);
+  });
 });


### PR DESCRIPTION
# Description

Changed some of the verification sugar functions to convert block number variables (from the verification contract) to timestamps (in seconds). This change does NOT include converting number of blocks (as amount) to a duration in seconds, because this is chain dependent and we would much rather have that on the front-end side of things.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added an extra test to Test_Verification.ts to test if the changed functions don't throw. Don't test anything inherently, because that's kind of hard to do. Did manually check the timestamp by logging them though.