### PR TITLE
fix: update ipfs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 Diamond Governance is a very flexible plugin for AragonOSx. It acts as a bridge between the Aragon framework and [ERC-2535 facets](https://eips.ethereum.org/EIPS/eip-2535). Multiple facets to customize the plugin are included in the project. Currently, the plugin is only available on Mumbai, but it will launch on Polygon before the end of June. 
 
 # SDK
-A typescript sdk is available for this plugin, allowing developers to easily communicate with the plugin in their projects. It can be found on [npm](https://www.npmjs.com/package/@plopmenz/diamond-governance-sdk?activeTab=readme).
+A typescript sdk is available for this plugin, allowing developers to easily communicate with the plugin in their projects. It can be found on [npm](https://www.npmjs.com/package/@secureseco-dao/diamond-governance-sdk).
 
 # Facets
 ## Governance

--- a/utils/ipfsHelper.ts
+++ b/utils/ipfsHelper.ts
@@ -33,7 +33,7 @@ export async function addToIpfs(json: string): Promise<string> {
 
     const config = {
       method: "POST",
-      url: "https://ipfs-0.aragon.network/api/v0/add",
+      url: "https://prod.ipfs.aragon.network/api/v0/add",
       headers: {
         "X-API-KEY": "b477RhECf8s8sdM7XrkLBs2wHc4kCMwpbcFC55Kt" // Publicly known Aragon IPFS node API key
       },
@@ -51,7 +51,7 @@ export async function getFromIpfs(hash: string): Promise<any> {
   
   const config = {
     method: "POST",
-    url: "https://ipfs-0.aragon.network/api/v0/cat?arg=" + hash,
+    url: "https://prod.ipfs.aragon.network/api/v0/cat?arg=" + hash,
     headers: {
       "X-API-KEY": "b477RhECf8s8sdM7XrkLBs2wHc4kCMwpbcFC55Kt" // Publicly known Aragon IPFS node API key
     },


### PR DESCRIPTION
# Description

Update the IPFS url of Aragon, as the old link does not seem to be supported anymore (preventing access to IPFS).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
